### PR TITLE
Fix release path for deploy and update the inventory library 0.6.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile 'com.madgag.spongycastle:pkix:1.54.0.0'
     compile 'com.orhanobut:logger:2.1.1'
     compile 'com.google.code.gson:gson:2.8.1'
-    compile 'org.flyve:inventory:0.6.1@aar'
+    compile 'org.flyve:inventory:0.6.2@aar'
     compile 'com.bugsnag:bugsnag-android:4.1.3'
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,28 +20,31 @@ platform :android do
 
     desc "Beta release app. Deploy a new version to the Google Play Store - Beta channel"
     lane :cert do |options|
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/app-release-unsigned.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk", log: true)
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner sign --ks ../ci/release.keystore --ks-key-alias mdmagent --ks-pass pass:"+ options[:storepass] +" --key-pass pass:"+ options[:keypass] +"  --out ../app/build/outputs/apk/app-ready.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk", log: true)
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner verify ../app/build/outputs/apk/app-ready.apk", log: true)
+        Fastlane::Actions.sh("pwd", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/release/app-release-unsigned.apk ../app/build/outputs/apk/release/app-release-unsigned-aligned.apk", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner sign --ks ../ci/release.keystore --ks-key-alias InventoryAgent --ks-pass pass:"+ options[:storepass] +" --key-pass pass:"+ options[:keypass] +"  --out ../app/build/outputs/apk/release/app-ready.apk ../app/build/outputs/apk/release/app-release-unsigned-aligned.apk", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner verify ../app/build/outputs/apk/release/app-ready.apk", log: true)
     end
     lane :beta do |options|
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/app-release-unsigned.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk", log: true)
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner sign --ks ../ci/release.keystore --ks-key-alias mdmagent --ks-pass pass:"+ options[:storepass] +" --key-pass pass:"+ options[:keypass] +"  --out ../app/build/outputs/apk/app-ready.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk", log: true)
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner verify ../app/build/outputs/apk/app-ready.apk", log: true)
+        Fastlane::Actions.sh("pwd", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/release/app-release-unsigned.apk ../app/build/outputs/apk/release/app-release-unsigned-aligned.apk", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner sign --ks ../ci/release.keystore --ks-key-alias InventoryAgent --ks-pass pass:"+ options[:storepass] +" --key-pass pass:"+ options[:keypass] +"  --out ../app/build/outputs/apk/release/app-ready.apk ../app/build/outputs/apk/release/app-release-unsigned-aligned.apk", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner verify ../app/build/outputs/apk/release/app-ready.apk", log: true)
 
         supply(
             track: 'beta',
-            apk: "app/build/outputs/apk/app-ready.apk"
+            apk: "app/build/outputs/apk/release/app-ready.apk"
         )
     end
     lane :playstore do |options|
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/app-release-unsigned.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk", log: true)
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner sign --ks ../ci/release.keystore --ks-key-alias mdmagent --ks-pass pass:"+ options[:storepass] +" --key-pass pass:"+ options[:keypass] +"  --out ../app/build/outputs/apk/app-ready.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk", log: true)
-        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner verify ../app/build/outputs/apk/app-ready.apk", log: true)
+        Fastlane::Actions.sh("pwd", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/release/app-release-unsigned.apk ../app/build/outputs/apk/release/app-release-unsigned-aligned.apk", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner sign --ks ../ci/release.keystore --ks-key-alias InventoryAgent --ks-pass pass:"+ options[:storepass] +" --key-pass pass:"+ options[:keypass] +"  --out ../app/build/outputs/apk/release/app-ready.apk ../app/build/outputs/apk/release/app-release-unsigned-aligned.apk", log: true)
+        Fastlane::Actions.sh("$ANDROID_HOME/build-tools/$BUILD_TOOL/apksigner verify ../app/build/outputs/apk/release/app-ready.apk", log: true)
 
         supply(
             track: 'production',
-            apk: "app/build/outputs/apk/app-ready.apk"
+            apk: "app/build/outputs/apk/release/app-ready.apk"
         )
     end
 end

--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -3,8 +3,8 @@
 app_package_name 'org.flyve.mdm.agent'
 use_tests_in_packages ['org.flyve.mdm.agent']
 
-app_apk_path 'app/build/outputs/apk/app-debug.apk'
-tests_apk_path 'app/build/outputs/apk/app-debug-androidTest.apk'
+app_apk_path '/home/circleci/flyve_mdm/app/build/outputs/apk/debug/app-debug.apk'
+tests_apk_path '/home/circleci/flyve_mdm/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk'
 
 locales ['en-US', 'en-GB', 'fr-FR', 'es-ES', 'ko-KR', 'ru-RU']
 


### PR DESCRIPTION
## Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [Conventional Commit](http://conventionalcommits.org/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The deploy on develop fail

```
Exit status of command '$ANDROID_HOME/build-tools/$BUILD_TOOL/zipalign -v -p 4 ../app/build/outputs/apk/app-release-unsigned.apk ../app/build/outputs/apk/app-release-unsigned-aligned.apk' was 1 instead of 0.
Unable to open '../app/build/outputs/apk/app-release-unsigned.apk' as zip archive
```

## What is the new behavior?
- The new path on gradle 3.0.1 was fixed
- Update the inventory library 0.6.2

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
