### PR TITLE
Downgrade Gradle to 4.1 for compatibility with instrumented test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,9 +56,9 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:2.7.22'
     implementation 'com.android.support:multidex:1.0.2'
     implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
-    implementation 'com.android.support:appcompat-v7:27.1.0'
-    implementation 'com.android.support:design:27.1.0'
-    implementation 'com.android.support:support-v4:27.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
 
     implementation "android.arch.persistence.room:runtime:1.0.0"
     annotationProcessor "android.arch.persistence.room:compiler:1.0.0"

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,9 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
-        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 29 20:20:34 BOT 2018
+#Tue Apr 10 17:31:11 BOT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
### Changes description

- Downgrade Gradle to 4.1 for compatibility with an instrumented test, without this instrumented test the deploy to Google Play is not working

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #

close: https://github.com/flyve-mdm/android-mdm-agent/issues/345