### PR TITLE
Fix fastlane deploy

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,11 +28,7 @@
     <!-- for location information -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-
     <uses-permission android:name="android.permission.CAMERA" />
-
-    <!-- Allows unlocking your device and activating its screen so UI tests can succeed -->
-    <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
 
     <!-- Allows changing locales -->
     <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
@@ -52,11 +48,9 @@
     <!-- Lock screen -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REORDER_TASKS" />
 
     <uses-permission android:name="android.permission.MODIFY_PHONE_STATE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.REBOOT" />
     <uses-permission android:name="android.permission.INSTALL_PACKAGES" />

--- a/ci/scripts/ci_deploy_beta.sh
+++ b/ci/scripts/ci_deploy_beta.sh
@@ -44,6 +44,9 @@ if [[ $GH_COMMIT_MESSAGE != *"ci(release): generate CHANGELOG.md for version"* &
 # create APK
 ./gradlew assemble
 
+# set the deploy type
+export DEPLOY_TYPE="beta"
+
 # run fastlane script
 ./ci/scripts/ci_fastlane.sh
 

--- a/ci/scripts/ci_deploy_production.sh
+++ b/ci/scripts/ci_deploy_production.sh
@@ -47,6 +47,9 @@ if [[ $GH_COMMIT_MESSAGE != *"ci(release): generate CHANGELOG.md for version"* &
 # run push changes script
 ./ci/scripts/ci_push_changes.sh
 
+# set the deploy type
+export DEPLOY_TYPE="playstore"
+
 # run fastlane script
 ./ci/scripts/ci_fastlane.sh
 

--- a/ci/scripts/ci_fastlane.sh
+++ b/ci/scripts/ci_fastlane.sh
@@ -28,4 +28,4 @@
 #
 
 # send to google play
-fastlane android $1 storepass:'$KEYSTORE' keypass:'$ALIAS'
+fastlane android $DEPLOY_TYPE storepass:'$KEYSTORE' keypass:'$ALIAS'


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
- The Fastlane deploy was not working because the variable deploy type "beta" or "playstore" was empty, to fix this export the variable on the bash script for beta and production

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@rafaelje |2|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A