### PR TITLE
Manage android application bundle with fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,13 +28,15 @@ platform :android do
     lane :beta do |options|
         supply(
             track: 'beta',
-            apk: "app/build/outputs/apk/release/appCertified.apk"
+            apk: "app/build/outputs/apk/release/appCertified.apk",
+            skip_upload_aab: true
         )
     end
     lane :playstore do |options|
         supply(
             track: 'production',
-            apk: "app/build/outputs/apk/release/appCertified.apk"
+            apk: "app/build/outputs/apk/release/appCertified.apk",
+            skip_upload_aab: true
         )
     end
 end


### PR DESCRIPTION
- With the implementation of the new Android application bundle https://developer.android.com/guide/app-bundle/ the supply on Fastlane fail, is mandatory to specify that the bundle is not supported

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@rafaelje |2|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A