### PR TITLE
Unenrollment policy fix and Add robotest deeplink

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,19 @@
         <activity
             android:name=".ui.MainActivity"
             android:configChanges="orientation|screenSize">
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="flyve"
+                    android:host="robotest"
+                    />
+            </intent-filter>
+
         </activity>
         <activity
             android:name=".ui.EnrollmentActivity"

--- a/app/src/main/assets/about.properties
+++ b/app/src/main/assets/about.properties
@@ -1,6 +1,6 @@
-about.version=2.0.0-rc.3
-about.build=2476
-about.date=Fri Sep 21 17:45:12 2018
+about.version=2.0.0-rc.4
+about.build=2518
+about.date=Mon Sep 24 11:22:42 2018
 about.commit=
 about.commitFull=
 about.github=https://github.com/flyve-mdm/flyve-mdm-android-agent

--- a/app/src/main/java/org/flyve/mdm/agent/data/database/FileData.java
+++ b/app/src/main/java/org/flyve/mdm/agent/data/database/FileData.java
@@ -42,4 +42,8 @@ public class FileData {
     public File[] getAllFiles() {
         return dataBase.FileDao().loadAll();
     }
+
+    public void deleteAll() {
+        dataBase.FileDao().deleteAll();
+    }
 }

--- a/app/src/main/java/org/flyve/mdm/agent/data/database/PoliciesData.java
+++ b/app/src/main/java/org/flyve/mdm/agent/data/database/PoliciesData.java
@@ -77,4 +77,8 @@ public class PoliciesData {
         Policies policies = dataBase.PoliciesDao().getPolicyBy(policyName, priority).get(0);
         dataBase.PoliciesDao().delete(policies);
     }
+
+    public void deleteAll() {
+        dataBase.PoliciesDao().deleteAll();
+    }
 }

--- a/app/src/main/java/org/flyve/mdm/agent/data/database/dao/PoliciesDao.java
+++ b/app/src/main/java/org/flyve/mdm/agent/data/database/dao/PoliciesDao.java
@@ -54,4 +54,6 @@ public interface PoliciesDao {
     @Query("Select * FROM policies where policyName = :policyName and priority = :priority order by priority desc limit 1")
     List<Policies> getPolicyBy(String policyName, int priority);
 
+    @Query("DELETE FROM policies")
+    void deleteAll();
 }

--- a/app/src/main/java/org/flyve/mdm/agent/services/PoliciesController.java
+++ b/app/src/main/java/org/flyve/mdm/agent/services/PoliciesController.java
@@ -35,7 +35,10 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.flyve.inventory.InventoryTask;
 import org.flyve.mdm.agent.BuildConfig;
 import org.flyve.mdm.agent.core.enrollment.EnrollmentHelper;
+import org.flyve.mdm.agent.data.database.ApplicationData;
+import org.flyve.mdm.agent.data.database.FileData;
 import org.flyve.mdm.agent.data.database.MqttData;
+import org.flyve.mdm.agent.data.database.PoliciesData;
 import org.flyve.mdm.agent.ui.MDMAgent;
 import org.flyve.mdm.agent.utils.FastLocationProvider;
 import org.flyve.mdm.agent.utils.FlyveLog;
@@ -398,6 +401,12 @@ public class PoliciesController {
 
             // clear cache
             mqttData.deleteAll();
+
+            // Remove all the information
+            new ApplicationData(context).deleteAll();
+            new FileData(context).deleteAll();
+            new MqttData(context).deleteAll();
+            new PoliciesData(context).deleteAll();
 
             // send message
             Helpers.sendBroadcast(Helpers.broadCastMessage("action", "open", "splash"), Helpers.BROADCAST_MSG, this.context);


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
- When unenrollment policy arrive at the device remove all the information
- Add a robotest deeplink to allow the Google Play and Firebase check inside the application with the robo, these deeplink allow to enter on the main screen without enrollment


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@rafaelje |5|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes: https://github.com/flyve-mdm/android-mdm-agent/issues/537
Related #N/A
Depends on #N/A