### PR TITLE
Add notification inputs

### DIFF
--- a/app/src/main/java/org/flyve/mdm/agent/core/enrollment/EnrollmentModel.java
+++ b/app/src/main/java/org/flyve/mdm/agent/core/enrollment/EnrollmentModel.java
@@ -168,6 +168,10 @@ public class EnrollmentModel implements Enrollment.Model {
             payload.put("type", "android");
             payload.put("has_system_permission", Helpers.isSystemApp(activity));
             payload.put("inventory", mInventory);
+            // could be mqtt or fcm
+            payload.put("notification_type", "mqtt");
+            // this is the token get from fcm register
+            payload.put("notification_token", "");
 
             FlyveLog.d(mInventory);
 


### PR DESCRIPTION
Signed-off-by: Rafa Hernandez <rhernandez@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
Send the input notification_type and notification_token on the enrollment payload, this implementation is just for mqtt in the fcm release will be able both

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@rafaelje |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes: https://github.com/flyve-mdm/android-mdm-agent/issues/640
Related #N/A
Depends on #N/A