### PR TITLE
Remove instrumentation test with Firebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,18 +197,10 @@ workflows:
               ignore:
                 - master
                 - develop
-      - test_instrumentation:
-          context: org-global
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - master
       - deploy_alpha:
           context: org-global
           requires:
-            - test_instrumentation
+            - build
           filters:
             branches:
               only:
@@ -224,7 +216,7 @@ workflows:
       - documentation:
           context: org-global
           requires:
-            - test_instrumentation
+            - build
           filters:
             branches:
               only:


### PR DESCRIPTION
Signed-off-by: Rafa Hernandez <rhernandez@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
- "ERROR: (gcloud.firebase.test.android.run) Http error while creating test matrix: ResponseError 429: Insufficient test quota." now we have 2 apks to test and has just 10 opportunity to test, it's remove the instrumentation test and replace by build on the workflow

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@rafaelje |3|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A