### PR TITLE
Fix build failed for licences not accepted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,17 @@ reference:
       name: Validate running
       command: source ci/scripts/validate_running.sh
 
+  update_licenses: &update_licenses
+    run:
+      name: Update licenses
+      command: source ci/scripts/ci_licenses.sh
 jobs:
   # unit test
   build:
     <<: *android_config
     steps:
       - checkout
+      - *update_licenses
       - *validate_running
       - *restore_gradle_cache
       - *ruby_dependencies
@@ -83,6 +88,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *update_licenses
       - *validate_running
       - *restore_gradle_cache
       - *ruby_dependencies
@@ -99,6 +105,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *update_licenses
       - *validate_running
       - *restore_gradle_cache
       - *ruby_dependencies
@@ -118,6 +125,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *update_licenses
       - *validate_running
       - *restore_gradle_cache
       - *ruby_dependencies
@@ -141,6 +149,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *update_licenses
       - *validate_running
       - *restore_gradle_cache
       - *ruby_dependencies
@@ -170,6 +179,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *update_licenses
       - *validate_running
       - *restore_gradle_cache
       - *ruby_dependencies

--- a/ci/scripts/ci_licenses.sh
+++ b/ci/scripts/ci_licenses.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+#  LICENSE
+#
+#  This file is part of Flyve MDM Inventory Library for Android.
+#
+#  Inventory Library for Android is a subproject of Flyve MDM.
+#  Flyve MDM is a mobile device management software.
+#
+#  Flyve MDM is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 3
+#  of the License, or (at your option) any later version.
+#
+#  Flyve MDM is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  ---------------------------------------------------------------------
+#  @copyright Copyright © 2018 Teclib. All rights reserved.
+#  @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+#  @link      https://github.com/flyve-mdm/android-inventory-library/
+#  @link      http://flyve.org/android-inventory-library/
+#  @link      https://flyve-mdm.com/
+#  ---------------------------------------------------------------------
+#
+
+ # Manage sdk licenses
+yes | sdkmanager --licenses || if [ $? -ne '141' ]; then exit $?; fi;


### PR DESCRIPTION
Fix error on circle CI when trying to build 

```
Warning: License for package Android SDK Build-Tools 28.0.2 not accepted.
Checking the license for package Android SDK Platform 27 in /opt/android/sdk/licenses
Warning: License for package Android SDK Platform 27 not accepted.

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> Failed to install the following Android SDK packages as some licences have not been accepted.
     platforms;android-27 Android SDK Platform 27
     build-tools;28.0.2 Android SDK Build-Tools 28.0.2
  To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
  Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
  
  Using Android SDK: /opt/android/sdk
```

