### PR TITLE
Fix send GPS status when it's not available

### DIFF
--- a/app/src/fcm/java/org/flyve/mdm/agent/ui/PoliciesAsyncTask.java
+++ b/app/src/fcm/java/org/flyve/mdm/agent/ui/PoliciesAsyncTask.java
@@ -96,6 +96,7 @@ public class PoliciesAsyncTask extends AsyncTask<Object, Integer, Boolean> {
 
                                             jsonPayload.put("_datetime", Helpers.getUnixTime());
                                             jsonPayload.put("_agents_id", new MqttData(context).getAgentId());
+                                            jsonPayload.put("computers_id", new MqttData(context).getComputersId());
                                             jsonPayload.put("_gps", "off");
 
                                             JSONObject jsonInput = new JSONObject();
@@ -145,7 +146,8 @@ public class PoliciesAsyncTask extends AsyncTask<Object, Integer, Boolean> {
                                     jsonPayload.put("_datetime", Helpers.getUnixTime());
                                     jsonPayload.put("_agents_id", new MqttData(context).getAgentId());
                                     jsonPayload.put("_gps", "off");
-
+                                    jsonPayload.put("computers_id", new MqttData(context).getComputersId());
+                                    
                                     JSONObject jsonInput = new JSONObject();
                                     jsonInput.put("input", jsonPayload);
 


### PR DESCRIPTION
### Changes description

When GLPI user request geolocalisation, if GPS is not available, MDM agent does not send the status "off" because the associated device is mandatory.

This PR fix it.

the tests pass locally but there is an issue with an empty var on CircleCI

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@stonebuzz |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A