### PR TITLE
fix obselete function

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ static def releaseTime() {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '28.0.2'
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId 'org.flyve.mdm.agent'
         minSdkVersion 16
@@ -35,9 +35,9 @@ android {
     }
     android.applicationVariants.all { variant ->
         variant.outputs.all { output ->
-            def outputFile = output.outputFile
-            if (outputFile != null && outputFile.name.endsWith('.apk')) {
-                def fileName = outputFile.name.replace("app",
+            def outputFile = outputFileName
+            if (outputFile != null && outputFile.endsWith('.apk')) {
+                def fileName = outputFile.replace("app",
                         "${defaultConfig.applicationId}_${releaseTime()}")
                 outputFileName = fileName
 

--- a/app/src/main/assets/about.properties
+++ b/app/src/main/assets/about.properties
@@ -1,6 +1,6 @@
 about.version=
 about.build=3407
-about.date=mer. oct. 16 14:05:39 2019
+about.date=mer. oct. 16 14:38:45 2019
 about.commit=
 about.commitFull=
 about.github=https://github.com/flyve-mdm/flyve-mdm-android-agent


### PR DESCRIPTION
Signed-off-by: Teclib <skita@teclib.com>
### Description

Fix obselete function 

```
WARNING: API 'variantOutput.getPackageApplication()' is obsolete and has been replaced with 'variant.getPackageApplicationProvider()'.
It will be removed at the end of 2019.

```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A