### PR TITLE
fix android SDK version

### DIFF
--- a/ci/scripts/generate_documentation.sh
+++ b/ci/scripts/generate_documentation.sh
@@ -30,7 +30,7 @@
 DOC_PATH="development/code-documentation/$CIRCLE_BRANCH"
 
 # Generate javadoc this folder must be on .gitignore
-javadoc -d $DOC_PATH -sourcepath ./app/src/main/java -subpackages . -bootclasspath $ANDROID_HOME/platforms/android-28/android.jar
+javadoc -d $DOC_PATH -sourcepath ./app/src/main/java -subpackages . -bootclasspath $ANDROID_HOME/platforms/android-29/android.jar
 
 # delete the index.html file
 sudo rm $DOC_PATH/index.html


### PR DESCRIPTION
Signed-off-by: Teclib <skita@teclib.com>

### Changes description

Fix CircleCI job to generate javadoc which use bad version of android sdk

```
Picked up _JAVA_OPTIONS: -Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
Loading source files for package org.flyve.mdm.agent.data.localstorage...
Loading source files for package org.flyve.mdm.agent.data.database...
Loading source files for package org.flyve.mdm.agent.data.database.setup...
Loading source files for package org.flyve.mdm.agent.data.database.dao...
Loading source files for package org.flyve.mdm.agent.data.database.entity...
Loading source files for package org.flyve.mdm.agent.service...
Loading source files for package org.flyve.mdm.agent.ui...
Loading source files for package org.flyve.mdm.agent.utils...
Loading source files for package org.flyve.mdm.agent.core.deeplink...
Loading source files for package org.flyve.mdm.agent.core...
Loading source files for package org.flyve.mdm.agent.core.user...
Loading source files for package org.flyve.mdm.agent.core.permission...
Loading source files for package org.flyve.mdm.agent.core.walkthrough...
Loading source files for package org.flyve.mdm.agent.policies...
Loading source files for package org.flyve.mdm.agent.receivers...
Loading source files for package org.flyve.mdm.agent.adapter...
Constructing Javadoc information...
com.sun.tools.javac.util.FatalError: Fatal Error: Unable to find package java.lang in classpath or bootclasspath
	at com.sun.tools.javac.comp.MemberEnter.importAll(MemberEnter.java:160)
	at com.sun.tools.javac.comp.MemberEnter.visitTopLevel(MemberEnter.java:525)
	at com.sun.tools.javac.tree.JCTree$JCCompilationUnit.accept(JCTree.java:518)
	at com.sun.tools.javac.comp.MemberEnter.memberEnter(MemberEnter.java:437)
	at com.sun.tools.javac.comp.MemberEnter.complete(MemberEnter.java:1038)
	at com.sun.tools.javac.code.Symbol.complete(Symbol.java:574)
	at com.sun.tools.javac.code.Symbol$ClassSymbol.complete(Symbol.java:1037)
	at com.sun.tools.javac.comp.Enter.complete(Enter.java:493)
	at com.sun.tools.javac.comp.Enter.main(Enter.java:471)
	at com.sun.tools.javadoc.JavadocEnter.main(JavadocEnter.java:78)
	at com.sun.tools.javadoc.JavadocTool.getRootDocImpl(JavadocTool.java:186)
	at com.sun.tools.javadoc.Start.parseAndExecute(Start.java:346)
	at com.sun.tools.javadoc.Start.begin(Start.java:219)
	at com.sun.tools.javadoc.Start.begin(Start.java:205)
	at com.sun.tools.javadoc.Main.execute(Main.java:64)
	at com.sun.tools.javadoc.Main.main(Main.java:54)
javadoc: error - fatal error
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A