### PR TITLE
update circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.10-stretch-node
+      - image: circleci/golang:1.13-stretch-node
     working_directory: ~/project-site
     branches:
       only:


### PR DESCRIPTION
Signed-off-by: Teclib <skita@teclib.com>

### Changes description

fix circleci build issue
```
#!/bin/bash -eo pipefail
source ci/installation.sh

Reading package lists... Done


Building dependency tree       


Reading state information... Done

The following additional packages will be installed:
  dpkg-dev fakeroot fonts-lato javascript-common libalgorithm-diff-perl
  libalgorithm-diff-xs-perl libalgorithm-merge-perl libfakeroot libgmp-dev
  libgmpxx4ldbl libjs-jquery libruby2.3 libyaml-0-2 patch rake ruby
  ruby-did-you-mean ruby-minitest ruby-net-telnet ruby-power-assert
  ruby-test-unit ruby2.3 ruby2.3-dev rubygems-integration
Suggested packages:
  debian-keyring apache2 | lighttpd | httpd gmp-doc libgmp10-doc libmpfr-dev
  ed diffutils-doc ri bundler
The following NEW packages will be installed:
  build-essential dpkg-dev fakeroot fonts-lato javascript-common
  libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl
  libfakeroot libgmp-dev libgmpxx4ldbl libjs-jquery libruby2.3 libyaml-0-2
  patch rake ruby ruby-dev ruby-did-you-mean ruby-minitest ruby-net-telnet
  ruby-power-assert ruby-test-unit ruby2.3 ruby2.3-dev rubygems-integration
0 upgraded, 26 newly installed, 0 to remove and 11 not upgraded.
Need to get 10.2 MB of archives.
After this operation, 37.6 MB of additional disk space will be used.

Get:1 http://deb.debian.org/debian stretch/main amd64 fonts-lato all 2.0-1 [2684 kB]

Get:2 http://deb.debian.org/debian stretch/main amd64 patch amd64 2.7.5-1+deb9u1 [112 kB]

Get:3 http://deb.debian.org/debian stretch/main amd64 dpkg-dev all 1.18.25 [1595 kB]

Get:4 http://deb.debian.org/debian stretch/main amd64 build-essential amd64 12.3 [7346 B]

Get:5 http://deb.debian.org/debian stretch/main amd64 libfakeroot amd64 1.21-3.1 [45.7 kB]

Get:6 http://deb.debian.org/debian stretch/main amd64 fakeroot amd64 1.21-3.1 [85.6 kB]

Get:7 http://deb.debian.org/debian stretch/main amd64 javascript-common all 11 [6120 B]

Get:8 http://deb.debian.org/debian stretch/main amd64 libalgorithm-diff-perl all 1.19.03-1 [48.7 kB]

Get:9 http://deb.debian.org/debian stretch/main amd64 libalgorithm-diff-xs-perl amd64 0.04-4+b2 [11.6 kB]

Get:10 http://deb.debian.org/debian stretch/main amd64 libalgorithm-merge-perl all 0.08-3 [12.7 kB]

Get:11 http://deb.debian.org/debian stretch/main amd64 libgmpxx4ldbl amd64 2:6.1.2+dfsg-1 [22.2 kB]

Get:12 http://deb.debian.org/debian stretch/main amd64 libgmp-dev amd64 2:6.1.2+dfsg-1 [631 kB]

Err:13 http://security.debian.org/debian-security stretch/updates/main amd64 libruby2.3 amd64 2.3.3-1+deb9u4
  404  Not Found

Err:14 http://deb.debian.org/debian stretch/main amd64 libjs-jquery all 3.1.1-2
  404  Not Found

Get:15 http://deb.debian.org/debian stretch/main amd64 libyaml-0-2 amd64 0.1.7-2 [47.6 kB]

Get:16 http://deb.debian.org/debian stretch/main amd64 rubygems-integration all 1.11 [4994 B]

Get:17 http://deb.debian.org/debian stretch/main amd64 ruby-did-you-mean all 1.0.0-2 [11.2 kB]

Get:18 http://deb.debian.org/debian stretch/main amd64 ruby-minitest all 5.9.0-1 [51.1 kB]

Get:19 http://deb.debian.org/debian stretch/main amd64 ruby-net-telnet all 0.1.1-2 [12.5 kB]

Get:20 http://deb.debian.org/debian stretch/main amd64 ruby-power-assert all 0.3.0-1 [7902 B]

Get:21 http://deb.debian.org/debian stretch/main amd64 ruby-test-unit all 3.1.7-2 [69.6 kB]

Err:22 http://security.debian.org/debian-security stretch/updates/main amd64 ruby2.3 amd64 2.3.3-1+deb9u4
  404  Not Found

Get:23 http://deb.debian.org/debian stretch/main amd64 ruby amd64 1:2.3.3 [10.8 kB]

Get:24 http://deb.debian.org/debian stretch/main amd64 rake all 10.5.0-2 [49.4 kB]

Get:25 http://deb.debian.org/debian stretch/main amd64 ruby-dev amd64 1:2.3.3 [9574 B]

Err:26 http://security.debian.org/debian-security stretch/updates/main amd64 ruby2.3-dev amd64 2.3.3-1+deb9u4
  404  Not Found

Fetched 5537 kB in 0s (17.6 MB/s)
E: Failed to fetch http://deb.debian.org/debian/pool/main/j/jquery/libjs-jquery_3.1.1-2_all.deb  404  Not Found
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/r/ruby2.3/libruby2.3_2.3.3-1+deb9u4_amd64.deb  404  Not Found
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/r/ruby2.3/ruby2.3_2.3.3-1+deb9u4_amd64.deb  404  Not Found
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/r/ruby2.3/ruby2.3-dev_2.3.3-1+deb9u4_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Exited with code 100
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A