### PR TITLE
fix(core): allow use clear text traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
 
         <receiver
             android:enabled="true"

--- a/app/src/main/assets/about.properties
+++ b/app/src/main/assets/about.properties
@@ -1,6 +1,6 @@
 about.version=
 about.build=3737
-about.date=jeu. nov. 07 15:43:40 2019
+about.date=jeu. nov. 07 16:25:59 2019
 about.commit=
 about.commitFull=
 about.github=https://github.com/flyve-mdm/flyve-mdm-android-agent


### PR DESCRIPTION
Signed-off-by: Teclib <skita@teclib.com>

### Changes description

with android 29, is mandatory to allow to use clear text traffic, when agent need to be discuss with a no secure GLPI (ie : only http) 

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A